### PR TITLE
Add project structure linting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,9 +16,15 @@
 	},
 	"plugins": [
 		"@typescript-eslint",
-		"react-refresh"
+		"react-refresh",
+		"project-structure"
 	],
+	"settings": {
+        "project-structure/config-path": "project-structure.json"
+    },
 	"rules": {
+		"project-structure/file-structure": "error",
+		"storybook/default-exports": "off",
 		"indent": ["warn", "tab", {
 			"SwitchCase": 2,
 			"FunctionExpression": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "@vitejs/plugin-react": "^4.2.1",
         "babel-jest": "^29.7.0",
         "eslint": "^8.57.0",
+        "eslint-plugin-project-structure": "^1.4.7",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.6",
         "eslint-plugin-storybook": "^0.8.0",
@@ -8586,6 +8587,192 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/eslint-plugin-project-structure": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-project-structure/-/eslint-plugin-project-structure-1.4.7.tgz",
+      "integrity": "sha512-VwcamMFxxE52D0qRQImwLfNEuXpN6OaOxlWNGNjigXRRMxz4/EHy/iw3k63bpfrBEli4CLfnvrbPt83NQE1wEg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/utils": "^5.57.0",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-project-structure/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-project-structure/node_modules/@typescript-eslint/types": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-project-structure/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-project-structure/node_modules/@typescript-eslint/utils": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-project-structure/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-project-structure/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/eslint-plugin-project-structure/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-project-structure/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/eslint-plugin-project-structure/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/eslint-plugin-project-structure/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-project-structure/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-project-structure/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "4.6.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "storybook dev --port 6006",
     "lint": "eslint ./src --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint:structure": "eslint --parser ./node_modules/eslint-plugin-project-structure/dist/parser.js --rule project-structure/file-structure:error --ext .js,.jsx,.ts,.tsx,.html,.css,.svg,.png,.jpg,.json,.md .",
     "test:unit": "jest ./src/components/**/*.test.tsx",
     "storybook": "storybook dev --port 6006",
     "build": "storybook build",
@@ -48,6 +49,7 @@
     "@vitejs/plugin-react": "^4.2.1",
     "babel-jest": "^29.7.0",
     "eslint": "^8.57.0",
+    "eslint-plugin-project-structure": "^1.4.7",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.6",
     "eslint-plugin-storybook": "^0.8.0",

--- a/project-structure.json
+++ b/project-structure.json
@@ -1,0 +1,224 @@
+{
+	"regexParameters": {
+		"lowercase": "^[a-z]+$"
+	},
+	"structure": {
+        "children": [
+            {
+                "name": "public",
+                "children": [
+					{
+						"name": "/^${{kebab-case}}$/",
+						"extension": ["js", "css", "ico", "svg", "png", "jpg"]
+					},
+					{
+						"name": "/^${{lowercase}}$/",
+						"extension": ["js", "css", "ico", "svg", "png", "jpg"]
+					}
+				]
+            },
+            {
+                "name": "src",
+                "children": [
+                    {
+                        "name": "types",
+                        "extension": ["ts"]
+                    },
+					{
+						"name": "assets",
+						"children": []
+					},
+					{
+						"name": "vite-env.d",
+						"extension": ["ts"]
+					},
+					{
+						"name": "components",
+						"children": [
+                            {
+                                "name": "/^${{PascalCase}}$/",
+                                "children": [
+									{
+										"name": "/^${{ParentName}}$/",
+										"extension": ["tsx"]
+									},
+									{
+										"name": "/^${{ParentName}}(\\.(test|style|stories))?$/",
+										"extension": ["tsx", "ts"]
+									}
+								]
+                            }
+                        ]
+					},
+					{
+						"name": "providers",
+						"children": [
+                            {
+                                "name": "/^${{PascalCase}}$/",
+                                "children": [
+									{
+										"name": "/^${{ParentName}}$/",
+										"extension": ["tsx"]
+									},
+									{
+										"name": "/^${{ParentName}}(\\.(test|style|stories))?$/",
+										"extension": ["tsx", "ts"]
+									},
+									{
+										"name": "GlobalStyle",
+										"extension": ["tsx"]
+									},
+									{
+										"name": "fonts",
+										"extension": "css"
+									}
+								]
+                            }
+                        ]
+					},
+					{
+						"name": "themes",
+						"children": [
+							{
+								"name": "/^${{lowercase}}$/",
+								"extension": ["ts"]
+							},
+							{
+								"name": "index.d",
+								"extension": ["ts"]
+							}
+						]
+					}
+				]
+            },
+			{
+				"name": "docs",
+				"children": [
+					{
+						"name": "components",
+						"children": [
+							{
+								"name": "/^${{PascalCase}}$/",
+								"children": [
+									{
+										"name": "/^${{ParentName}}$/",
+										"extension": ["tsx"]
+									},
+									{
+										"name": "/^${{ParentName}}(\\.(test|style|stories))?$/",
+										"extension": ["tsx", "ts"]
+									}
+								]
+							}
+						]
+					},
+					{
+						"extension": ["mdx"]
+					}
+				]
+			},
+			{
+				"name": ".storybook",
+				"children": [
+					{
+						"name": "/^${{kebab-case}}$/",
+						"extension": ["html"]
+					},
+					{
+						"name": "/^${{lowercase}}$/",
+						"extension": ["ts"]
+					}
+				]
+			},
+			{
+				"name": "templates",
+				"children": [
+					{
+						"name": "TemplateName",
+						"extension": ["tsx"]
+					},
+					{
+						"name": "TemplateName.style",
+						"extension": ["ts", "tsx"]
+					},
+					{
+						"name": "TemplateName.test",
+						"extension": ["tsx"]
+					},
+					{
+						"name": "TemplateName.stories",
+						"extension": ["ts", "tsx"]
+					}
+				]
+			},
+			{
+				"name": "test-mocks",
+				"children": []
+			},
+			{
+				"name": ".eslintrc",
+				"extension": ["json"]
+			},
+			{
+				"name": ".babelrc"
+			},
+			{
+				"name": ".gitignore"
+			},
+			{
+				"name": "generate-react-cli",
+				"extension": ["json"]
+			},
+			{
+				"name": "index",
+				"extension": ["html"]
+			},
+			{
+				"name": "jest.config",
+				"extension": ["js", "ts"]
+			},
+			{
+				"name": "jest.setup",
+				"extension": ["js", "ts"]
+			},
+			{
+				"name": "LICENSE"
+			},
+			{
+				"name": "CODEOWNERS"
+			},
+			{
+				"name": "package",
+				"extension": ["json"]
+			},
+			{
+				"name": "package-lock",
+				"extension": ["json"]
+			},
+			{
+				"name": "project-structure",
+				"extension": ["json"]
+			},
+			{
+				"name": "README",
+				"extension": ["md"]
+			},
+			{
+				"name": "tsconfig",
+				"extension": ["json"]
+			},
+			{
+				"name": "tsconfig.node",
+				"extension": ["json"]
+			},
+			{
+				"name": "vite",
+				"extension": ["config.ts"]
+			},
+			{
+				"name": "vite.config",
+				"extension": ["ts"]
+			}
+        ]
+    }
+}


### PR DESCRIPTION
Adds project structure check using [eslint-plugin-project-structure](https://github.com/Igorkowalski94/eslint-plugin-project-structure) to ensure that additions to the codebase follow the directory structure and naming conventions specified in `project-structure.json`.

The check can be run from the command line using `npm run lint:structure`, with the intention that this will be set up as a CI step that must pass before a pull request can be merged.

This is similar to the PRs raised in the web app repositories, but some slightly different configuration is required due to the nature of this project (e.g., accounting for Storybook, the `docs` folder, etc). 