### PR TITLE
Update test configuration to make styled components work properly

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,9 +1,11 @@
 {
 	"presets": [
-		"@babel/preset-env",
-		["@babel/preset-react", {
-			"runtime": "automatic"
-		}],
+		["@babel/preset-env", { "targets": { "node": "current" } }],
+		["@babel/preset-react", { "runtime": "automatic" }],
 		"@babel/preset-typescript"
+	],
+	"plugins": [
+		"babel-plugin-styled-components",
+		"react-magnetic-di/babel-plugin"
 	]
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 export default {
 	testEnvironment: 'jsdom',
 	transform: {
-		'^.+\\.[t|j]sx?$': 'babel-jest',
+		'^.+\\.(tsx?|jsx?)$': 'babel-jest',
 	},
-	setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+	setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
 };

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,0 @@
-import '@testing-library/jest-dom';

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,6 @@
+import '@testing-library/jest-dom';
+
+jest.mock('./src/providers/RedbackUiThemeProvider/GlobalStyle.tsx', () => ({
+	GlobalStyle: () => null
+}));
+

--- a/jest.utils.tsx
+++ b/jest.utils.tsx
@@ -1,0 +1,23 @@
+import { DiProvider, injectable } from 'react-magnetic-di';
+import { ThemeProvider } from 'styled-components';
+import { ReactNode } from 'react';
+import RedbackUiThemeProvider from './src/providers/RedbackUiThemeProvider/RedbackUiThemeProvider.tsx';
+import defaultTheme from './src/themes/default.ts';
+import { render } from '@testing-library/react';
+
+const commonDeps = [
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	injectable(RedbackUiThemeProvider, ({ theme, children }) => {
+		return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+	}),
+];
+
+
+export const renderWithDeps = (component: ReactNode) => {
+	return render(
+		<DiProvider use={commonDeps}>
+			<RedbackUiThemeProvider theme={defaultTheme}>
+				{component}
+			</RedbackUiThemeProvider>
+		</DiProvider>);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "@typescript-eslint/parser": "^7.2.0",
         "@vitejs/plugin-react": "^4.2.1",
         "babel-jest": "^29.7.0",
+        "babel-plugin-styled-components": "^2.1.4",
         "eslint": "^8.57.0",
         "eslint-plugin-project-structure": "^1.4.7",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -46,6 +47,7 @@
         "jest-environment-jsdom": "^29.7.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-magnetic-di": "^3.1.2",
         "storybook": "^8.0.5",
         "storybook-dark-mode": "^4.0.1",
         "typescript": "^5.2.2",
@@ -6860,6 +6862,22 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+      }
+    },
+    "node_modules/babel-plugin-styled-components": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz",
+      "integrity": "sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.22.5",
+        "@babel/helper-module-imports": "^7.22.5",
+        "@babel/plugin-syntax-jsx": "^7.22.5",
+        "lodash": "^4.17.21",
+        "picomatch": "^2.3.1"
+      },
+      "peerDependencies": {
+        "styled-components": ">= 2"
       }
     },
     "node_modules/babel-preset-current-node-syntax": {
@@ -14763,6 +14781,24 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-magnetic-di": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/react-magnetic-di/-/react-magnetic-di-3.1.2.tgz",
+      "integrity": "sha512-FutzndjzqiuhsIeRDwICKOxl3VhAsN0BQi5oOfnAkde8WCua796ojAf1Qm+vUgAGpcdWaEd8kuN5ShkRiLBJ0Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.16.0"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.0.0",
+        "react": "^16.9.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-magnetic-di": "^3.1.2",
     "storybook": "^8.0.5",
     "storybook-dark-mode": "^4.0.1",
     "typescript": "^5.2.2",

--- a/project-structure.json
+++ b/project-structure.json
@@ -182,6 +182,10 @@
 				"extension": ["js", "ts"]
 			},
 			{
+				"name": "jest.utils",
+				"extension": ["ts", "tsx"]
+			},
+			{
 				"name": "LICENSE"
 			},
 			{

--- a/src/components/Alert/Alert.test.tsx
+++ b/src/components/Alert/Alert.test.tsx
@@ -1,12 +1,11 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import { renderWithDeps } from '../../../jest.utils.tsx';
 import Alert from './Alert';
 
 describe('<Alert />', () => {
-	it('should mount', () => {
-		render(<Alert>Example alert</Alert>);
+	it('renders', () => {
+		renderWithDeps(<Alert>Example alert</Alert>);
 
-		const alert = screen.getByTestId('Alert');
-
-		expect(alert).toBeInTheDocument();
+		expect( screen.getByText('Example alert')).toBeInTheDocument();
 	});
 });

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -1,12 +1,23 @@
-import { render, screen } from '@testing-library/react';
+import { screen, fireEvent }  from '@testing-library/react';
+import { renderWithDeps } from '../../../jest.utils.tsx';
 import Button from './Button';
 
+const mockClick = jest.fn();
+
 describe('<Button />', () => {
-	test('it should mount', () => {
-		render(<Button/>);
+	it('renders', () => {
+		renderWithDeps(<Button label="Test button" onClick={mockClick}/>);
 
-		const button = screen.getByTestId('Button');
+		expect(screen.getByRole('button', { name: 'Test button' })).toBeVisible();
+	});
 
-		expect(button).toBeInTheDocument();
+	it('calls the click handler',  () => {
+		renderWithDeps(<Button label="Test button" onClick={mockClick}/>);
+
+		const button = screen.getByRole('button', { name: 'Test button' });
+
+		fireEvent.click(button);
+
+		expect(mockClick).toHaveBeenCalledTimes(1);
 	});
 });

--- a/src/components/Label/Label.test.tsx
+++ b/src/components/Label/Label.test.tsx
@@ -1,12 +1,11 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import { renderWithDeps } from '../../../jest.utils.tsx';
 import Label from './Label';
 
 describe('<Label />', () => {
-	it('should mount', () => {
-		render(<Label/>);
+	it('renders', () => {
+		renderWithDeps(<Label type="info" text="Test label"/>);
 
-		const label = screen.getByTestId('Label');
-
-		expect(label).toBeInTheDocument();
+		expect(screen.getByText('Test label')).toBeVisible();
 	});
 });

--- a/src/components/LinkButton/LinkButton.test.tsx
+++ b/src/components/LinkButton/LinkButton.test.tsx
@@ -1,12 +1,11 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import { renderWithDeps } from '../../../jest.utils.tsx';
 import LinkButton from './LinkButton';
 
 describe('<LinkButton />', () => {
-	it('should mount', () => {
-		render(<LinkButton/>);
+	it('renders', () => {
+		renderWithDeps(<LinkButton label="Test link" href="#" />);
 
-		const linkButton = screen.getByTestId('LinkButton');
-
-		expect(linkButton).toBeInTheDocument();
+		expect(screen.getByRole('link', { name: 'Test link' })).toBeVisible();
 	});
 });

--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import { renderWithDeps } from '../../../jest.utils.tsx';
 import Table from './Table';
 
 describe('<Table />', () => {
-	it('should mount', () => {
-		render(<Table/>);
+	it('renders', () => {
+		renderWithDeps(<Table/>);
 
 		const table = screen.getByTestId('Table');
 

--- a/src/components/TruncatedText/TruncatedText.stories.ts
+++ b/src/components/TruncatedText/TruncatedText.stories.ts
@@ -10,7 +10,8 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const defaultProps = {
-
+	text: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec iaculis faucibus mattis. Sed eget magna urna. Quisque posuere vehicula pharetra. Pellentesque bibendum condimentum lacus, at elementum justo ultrices ut. Ut at ipsum vel metus condimentum venenatis. Ut varius nisi in massa porttitor mollis. Pellentesque ac auctor quam.',
+	lines: 2
 };
 
 const disableControls = {

--- a/src/components/TruncatedText/TruncatedText.style.ts
+++ b/src/components/TruncatedText/TruncatedText.style.ts
@@ -1,8 +1,9 @@
 import styled from 'styled-components';
 
 export const StyledTruncatedText = styled.span<{lines: number}>`
-	display: -webkit-box;
+	display: -webkit-box; // required for line clamping to work
+	-webkit-box-orient: vertical; // required for line clamping to work
 	-webkit-line-clamp: ${props => props.lines};
-	-webkit-box-orient: vertical;
 	overflow: hidden;
+	text-overflow: ellipsis;
 `;

--- a/src/components/TruncatedText/TruncatedText.test.tsx
+++ b/src/components/TruncatedText/TruncatedText.test.tsx
@@ -1,12 +1,13 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import { renderWithDeps } from '../../../jest.utils.tsx';
 import TruncatedText from './TruncatedText';
 
+const text = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec iaculis faucibus mattis. Sed eget magna urna. Quisque posuere vehicula pharetra. Pellentesque bibendum condimentum lacus, at elementum justo ultrices ut. Ut at ipsum vel metus condimentum venenatis. Ut varius nisi in massa porttitor mollis. Pellentesque ac auctor quam.';
+
 describe('<TruncatedText />', () => {
-	it('should mount', () => {
-		render(<TruncatedText/>);
+	it('renders', () => {
+		renderWithDeps(<TruncatedText text={text} lines={1}/>);
 
-		const truncatedText = screen.getByTestId('TruncatedText');
-
-		expect(truncatedText).toBeInTheDocument();
+		expect(screen.getByText('Lorem ipsum dolor sit amet', { exact:false })).toBeVisible();
 	});
 });

--- a/src/providers/RedbackUiThemeProvider/GlobalStyle.tsx
+++ b/src/providers/RedbackUiThemeProvider/GlobalStyle.tsx
@@ -1,5 +1,6 @@
 import { createGlobalStyle } from 'styled-components';
 import { rgba } from 'polished';
+import './fonts.css';
 
 export const GlobalStyle = createGlobalStyle`
 	body {

--- a/src/providers/RedbackUiThemeProvider/RedbackUiThemeProvider.style.ts
+++ b/src/providers/RedbackUiThemeProvider/RedbackUiThemeProvider.style.ts
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import './fonts.css';
 import { readableColor } from 'polished';
 
 export const RedbackUiWrapper = styled.div`

--- a/src/providers/RedbackUiThemeProvider/RedbackUiThemeProvider.test.tsx
+++ b/src/providers/RedbackUiThemeProvider/RedbackUiThemeProvider.test.tsx
@@ -3,11 +3,11 @@ import RedbackUiThemeProvider from './RedbackUiThemeProvider';
 import { themes } from '../../themes';
 
 describe('<RedbackUiThemeProvider />', () => {
-	it('should mount', () => {
+	it('renders', () => {
 		render(<RedbackUiThemeProvider theme={themes.default}>Content</RedbackUiThemeProvider>);
 
-		const redbackUiThemeProvider = screen.getByTestId('RedbackUiThemeProvider');
+		const redbackUiThemeProvider = screen.getByTestId('redback-ui.wrapper');
 
-		expect(redbackUiThemeProvider).toBeInTheDocument();
+		expect(redbackUiThemeProvider).toBeVisible();
 	});
 });

--- a/templates/TemplateName.test.tsx
+++ b/templates/TemplateName.test.tsx
@@ -1,9 +1,10 @@
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import { renderWithDeps } from '../../../jest.utils.tsx';
 import TemplateName from './TemplateName';
 
 describe('<TemplateName />', () => {
-	it('should mount', () => {
-		render(<TemplateName/>);
+	it('renders', () => {
+		renderWithDeps(<TemplateName />);
 
 		const templateName = screen.getByTestId('TemplateName');
 


### PR DESCRIPTION
- Update Babel configuration for Jest
- Mock the theme provider so a theme is received, but irrelevant bits that were causing errors (such as Google font import) are ignored
- Create a customised `renderWithDeps` function to automatically wrap tests in the mock theme provider and use any other injected dependencies we add here in the future
- Update usages of RTL `render` with the custom `renderWithDeps` function