### PR TITLE
Sortable table component

### DIFF
--- a/src/components/SortableTable/SortableTable.stories.ts
+++ b/src/components/SortableTable/SortableTable.stories.ts
@@ -1,0 +1,56 @@
+import { SortableTable } from './SortableTable';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta = {
+	title: 'Components/SortableTable',
+	component: SortableTable,
+} satisfies Meta<typeof SortableTable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const defaultProps = {
+	columns: [
+		{ value: 'id', label: 'ID', sortable: false, format: 'number' },
+		{ value: 'name', label: 'Name', sortable: true },
+		{ value: 'location', label: 'Location', sortable: true },
+		{ value: 'score', label: 'Score', sortable: true, format: 'number' },
+	],
+	initialData: [
+		{ id: '1', name: 'Example name 1', location: 'Some location', score: '4.5' },
+		{ id: '2', name: 'Example name 2', location: 'Some location', score: '7.5' },
+		{ id: '3', name: 'Example name 3', location: 'Some other location', score: '2.5' },
+		{ id: '4', name: 'Example name 4', location: 'Another location', score: '5.0' },
+		{ id: '5', name: 'Example name 5', location: 'Random location', score: '0.5' },
+		{ id: '6', name: 'Example name 6', location: 'Another location', score: '8.0' },
+		{ id: '7', name: 'Example name 7', location: 'Some location', score: '3.5' },
+		{ id: '8', name: 'Example name 8', location: 'Another location', score: '6.25' },
+		{ id: '9', name: 'Example name 9', location: 'Some other location', score: '1.5' },
+	],
+	initialSortField: 'score'
+};
+
+const disableControls = {
+	parameters: {
+		controls: {
+			disable: true
+		},
+		actions: {
+			disable: true
+		},
+	}
+};
+
+export const Demo: Story = {
+	args: {
+		...defaultProps
+	},
+	tags: ['excludeFromSidebar']
+};
+
+export const Default: Story = {
+	args: {
+		...defaultProps
+	},
+	...disableControls
+};

--- a/src/components/SortableTable/SortableTable.style.ts
+++ b/src/components/SortableTable/SortableTable.style.ts
@@ -1,0 +1,66 @@
+import styled from 'styled-components';
+import { readableColor, tint } from 'polished';
+
+export const StyledSortableTable = styled.table`
+	width: 100%;
+	margin-bottom: 1rem;
+	border-collapse: collapse;
+	border: 1px solid ${props => props.theme.colors.subtle};
+	background: ${props => props.theme.colors.background};
+
+	th, td {
+		font-family: ${props => props.theme.fontFamily.body};
+		text-align: left;
+		padding: ${props => props.theme.spacing.sm};
+		border-right: 1px solid ${props => tint(0.4, props.theme.colors.subtle)};
+	}
+
+	thead th {
+		background-color: ${props => props.theme.colors.secondary};
+        color: ${props => readableColor(props.theme.colors.secondary)};
+		border-right-color: ${props => tint(0.3, props.theme.colors.secondary)};
+		text-align: left;
+        
+        &[data-format="number"] {
+            width: 3rem;
+        }
+	}
+    
+    tbody td {
+        
+        &[data-format="number"] {
+            text-align: right;
+        }
+    }
+
+	tr:nth-child(even) {
+		background-color: ${props => tint(0.8, props.theme.colors.subtle)};
+	}
+`;
+
+export const StyledSortingButton = styled.button<{ $direction: 'asc' | 'desc', $active: boolean }>`
+	font-family: ${props => props.theme.fontFamily.body};
+	display: flex;
+	width: 100%;
+	justify-content: space-between;
+	align-items: center;
+	background: transparent;
+	border: 0;
+    border-bottom: 2px solid ${props => props.$active ? 'currentColor' : 'transparent'};
+	appearance: none;
+	font-size: inherit;
+	color: inherit;
+	font-weight: inherit;
+	outline: none;
+	cursor: pointer;
+	padding: 0;
+`;
+
+export const StyledSortIcon = styled.span<{ $direction: 'asc' | 'desc' }>`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    transition: transform 0.3s ease;
+    transform: rotate(${props => props.$direction === 'asc' ? '0' : '180deg'});
+    margin-inline-start: ${props => props.theme.spacing.sm};
+`;

--- a/src/components/SortableTable/SortableTable.test.tsx
+++ b/src/components/SortableTable/SortableTable.test.tsx
@@ -1,0 +1,66 @@
+import { screen, fireEvent } from '@testing-library/react';
+import { renderWithDeps } from '../../../jest.utils';
+import { SortableTable } from './SortableTable';
+import { axe } from 'jest-axe';
+
+const defaultProps = {
+	columns: [
+		{ value: 'id', label: 'ID', sortable: false, format: 'number' },
+		{ value: 'name', label: 'Name', sortable: true },
+		{ value: 'location', label: 'Location', sortable: true },
+		{ value: 'score', label: 'Score', sortable: true, format: 'number' },
+	],
+	initialData: [
+		{ id: '1', name: 'Example name 1', location: 'Some location', score: '4.5' },
+		{ id: '2', name: 'Example name 2', location: 'Some location', score: '7.5' },
+		{ id: '3', name: 'Example name 3', location: 'Some other location', score: '2.5' },
+		{ id: '4', name: 'Example name 4', location: 'Another location', score: '5.0' },
+		{ id: '5', name: 'Example name 5', location: 'Random location', score: '0.5' },
+		{ id: '6', name: 'Example name 6', location: 'Another location', score: '8.0' },
+		{ id: '7', name: 'Example name 7', location: 'Some location', score: '3.5' },
+		{ id: '8', name: 'Example name 8', location: 'Another location', score: '6.25' },
+		{ id: '9', name: 'Example name 9', location: 'Some other location', score: '1.5' },
+	],
+	initialSortField: 'score'
+};
+
+describe('<SortableTable />', () => {
+	it('renders', () => {
+		renderWithDeps(<SortableTable {...defaultProps} />);
+
+		const sortableTable = screen.getByTestId('SortableTable');
+
+		expect(sortableTable).toBeInTheDocument();
+	});
+
+	it('has no accessibility violations', async () => {
+		const { container } = renderWithDeps(<SortableTable {...defaultProps} />);
+		const results = await axe(container);
+
+		expect(results).toHaveNoViolations();
+	});
+
+	it('renders with the data sorted by the initial sort field', () => {
+		renderWithDeps(<SortableTable {...defaultProps} />);
+
+		// Check a pseudo-random selection of rows for the expected values
+		const rows = screen.getAllByRole('row');
+		expect(rows[1]).toHaveTextContent('Example name 5');
+		expect(rows[2]).toHaveTextContent('Example name 9');
+		expect(rows[4]).toHaveTextContent('Example name 7');
+		expect(rows[9]).toHaveTextContent('Example name 6');
+	});
+
+	it('sorts by another field when the button in the column header is clicked', () => {
+		renderWithDeps(<SortableTable {...defaultProps} />);
+
+		const nameButton = screen.getByRole('button', { name: /Name\s*/i });
+		fireEvent.click(nameButton);
+
+		// Check a pseudo-random selection of rows for the expected values
+		const rows = screen.getAllByRole('row');
+		expect(rows[1]).toHaveTextContent('Example name 9');
+		expect(rows[5]).toHaveTextContent('Example name 5');
+		expect(rows[9]).toHaveTextContent('Example name 1');
+	});
+});

--- a/src/components/SortableTable/SortableTable.tsx
+++ b/src/components/SortableTable/SortableTable.tsx
@@ -1,0 +1,168 @@
+import React, { FC, useCallback, useEffect, useState } from 'react';
+import { StyledSortableTable, StyledSortIcon, StyledSortingButton } from './SortableTable.style';
+
+type Column = {
+    value: keyof Row;
+    label: string;
+    sortable?: boolean;
+    format?: 'text' | 'number' | string; // affects the styling
+};
+
+type Row = {
+    [key: string]: string;
+};
+
+type Order = 'asc' | 'desc';
+
+type SortableTableProps = {
+    columns: Column[];
+    initialData: Row[];
+    initialSortField: keyof Row;
+};
+
+type SortingButtonProps = {
+    label: string;
+    direction: Order;
+    onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+    active: boolean;
+};
+
+/**
+ * Function to sort the rows based on a given field name and order
+ * @param data
+ * @param field
+ * @param order
+ */
+function sortRows(data: Row[], field: keyof Row, order: Order) {
+	return data.sort((a, b) => {
+		let aValue: string | number = a[field];
+		let bValue: string | number = b[field];
+
+		// Check if values can be converted to numbers
+		if (!isNaN(parseFloat(aValue)) && !isNaN(parseFloat(bValue))) {
+			aValue = parseFloat(aValue);
+			bValue = parseFloat(bValue);
+		}
+
+		// Check if the values are strings
+		if (typeof aValue === 'string' && typeof bValue === 'string') {
+			const comparison = aValue.localeCompare(bValue);
+
+			return order === 'asc' ? comparison : -comparison;
+		}
+
+		// Otherwise, assume the values are numbers or comparable
+		if (aValue > bValue) {
+			return order === 'asc' ? 1 : -1;
+		}
+		if (aValue < bValue) {
+			return order === 'asc' ? -1 : 1;
+		}
+
+		return 0;
+	});
+}
+
+/**
+ * Inner component for the sorting button
+ * @param label
+ * @param direction
+ * @param onClick
+ * @param active
+ * @constructor
+ */
+const SortingButton: FC<SortingButtonProps> = ({ label, direction, onClick, active = false }) => {
+	return (
+		<StyledSortingButton data-testid="SortingButton" onClick={onClick} $direction={direction} $active={active}>
+			{label}
+			<StyledSortIcon $direction={direction}>
+				<span className="arrow">&darr;</span>
+			</StyledSortIcon>
+		</StyledSortingButton>
+	);
+};
+
+/**
+ * The actual SortableTable component
+ * @param columns
+ * @param initialData
+ * @param initialSortField
+ * @constructor
+ */
+export const SortableTable: FC<SortableTableProps> = ({ columns, initialData, initialSortField }) => {
+	// The data set that will be displayed - allows for sorting, filtering, etc. without mutating the original data
+	const [data, setData] = useState<Row[]>([]);
+	const [activeSortField, setActiveSortField] = useState<string>(initialSortField.toString());
+
+	// Re-sync `data` state with `initialData` prop whenever it changes
+	useEffect(() => {
+		setData(sortRows(initialData, initialSortField, 'asc'));
+	}, [initialData, initialSortField]);
+
+	const sortableColumns = columns.filter(column => column.sortable);
+
+	const [ordering, setOrdering] = useState<{ [key: string]: Order }>(() => {
+		const order = {};
+		sortableColumns.forEach(column => {
+			Object.assign(order, { [column.value]: 'asc' });
+		});
+
+		return order;
+	});
+
+	const handleSort = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+		const sort = (field: keyof Row, order: Order) => {
+			setData(() => sortRows(data, field, order));
+		};
+
+		const field = event.currentTarget.closest('th')?.dataset.fieldkey as keyof Row;
+		if(field) {
+			const newOrder: Order = ordering[field] === 'asc' ? 'desc' : 'asc';
+			sort(field, newOrder);
+			setActiveSortField(field.toString());
+			setOrdering(prevOrdering => ({
+				...prevOrdering,
+				[field]: newOrder,
+			}));
+		}
+	}, [data, ordering]);
+
+	const cellContent = (row: Row, columnValue: string) => {
+		return row[columnValue as keyof Row];
+	};
+
+	return (
+		data && (
+			<StyledSortableTable data-testId="SortableTable">
+				<thead>
+					<tr>
+						{columns.map((column) => (
+							<th key={column.value} data-fieldkey={column.value} data-format={column?.format ?? 'text'}>
+								{sortableColumns.find(sortable => column.value === sortable.value) ? (
+									<SortingButton label={column.label}
+										direction={ordering[column.value]}
+										onClick={handleSort}
+										active={activeSortField === column.value}
+									/>
+								) : (
+									<>{column.label}</>
+								)}
+							</th>
+						))}
+					</tr>
+				</thead>
+				<tbody>
+					{data.map((row) => (
+						<tr key={`row-${row.id}`}>
+							{columns.map((column, columnIndex) => (
+								<td key={columnIndex} data-fieldkey={column.value} data-format={column?.format ?? 'text'}>
+									{cellContent(row, column.value.toString())}
+								</td>
+							))}
+						</tr>
+					))}
+				</tbody>
+			</StyledSortableTable>
+		)
+	);
+};


### PR DESCRIPTION
## Summary

What is the nature of this pull request?

- [x] New feature
- [ ] Enhancement to an existing feature
- [ ] Bug fix
- [ ] Configuration update
- [ ] Dependency update

### Description of change
This PR adds a sortable table component. Consumers can pass in rows with matching column names, and specify whether those columns are sortable. For those that are, a button is rendered in the table header that re-sorts the rows when clicked. A default column to sort by should also be specified for the initial rendering. 

### Planner card link
[Redback UI - Sortable table component](https://planner.cloud.microsoft/deakin365.onmicrosoft.com/en-US/Home/Planner/#/plantaskboard?groupId=d4b3d587-9b20-4ac0-9de2-b842fd9dce46&planId=TOGdCftBI0mZ937fEIW0jsgAHPsL)

## Readiness

- [x] The application runs successfully with my change.
- [x] I have included [code comments](https://stackoverflow.blog/2021/12/23/best-practices-for-writing-code-comments/) where appropriate.
- N/A Where I have copied and pasted code from other sources, I have included a comment with a link to the original source.
- [x] I have read and followed the [principles and guidelines about submitting code](https://redback-operations.github.io/redback-documentation/docs/web-mobile-app-dev/frontend/submitting-work).
- [x] I have added [unit tests](https://redback-operations.github.io/redback-documentation/docs/web-mobile-app-dev/frontend/tests) for new components and/or functionality.
- [x] All existing and new unit tests pass (including updating tests for any necessary breaking changes).
